### PR TITLE
Fix encoding of regexps for Ruby 2.0

### DIFF
--- a/lib/rmail/address.rb
+++ b/lib/rmail/address.rb
@@ -703,7 +703,7 @@ module RMail
 	    @sym = SYM_DOMAIN_LITERAL
 	    @lexeme = $1.gsub(/(^|[^\\])[\r\n\t ]+/, '\1').gsub(/\\(.)/, '\1')
 	    break
-          when /\A[\200-\377\w!$%&\'*+\/=?^_\`{\}|~#-]+/m
+          when /\A[\200-\377\w!$%&\'*+\/=?^_\`{\}|~#-]+/nm
             # This is just like SYM_ATOM, but includes all characters
             # with high bits.  This is so we can allow such tokens in
             # the display name portion of an address even though it

--- a/lib/rmail/header.rb
+++ b/lib/rmail/header.rb
@@ -73,7 +73,7 @@ module RMail
 
     class Field                 # :nodoc:
       # fixme, document methadology for this (RFC2822)
-      EXTRACT_FIELD_NAME_RE = /\A([^\x00-\x1f\x7f-\xff :]+):\s*/o
+      EXTRACT_FIELD_NAME_RE = /\A([^\x00-\x1f\x7f-\xff :]+):\s*/no
 
       class << self
         def parse(field)


### PR DESCRIPTION
This simply fixes the issue with Ruby 2.0 and its default UTF-8 encoding.

It fixes `invalid multibyte escape` error:

```
invalid multibyte escape: /\A[\200-\377\w!$%&\'*+\/=?^_\`{\}|~#-]+/m (SyntaxError)
```
