### PR TITLE
Ruby 2.0 fixes for the test suite

### DIFF
--- a/test/testaddress.rb
+++ b/test/testaddress.rb
@@ -809,14 +809,14 @@ class TestRMailAddress < TestBase
   def test_invalid_addresses()
     # The display name isn't encoded -- bad, but we parse it.
     validate_case\
-    ["\322\315\322 \312\353\363\341 <bar@foo.invalid>",
-      [ { :name => "\322\315\322 \312\353\363\341",
-	  :display_name => "\322\315\322 \312\353\363\341",
+    ["\322\315\322 \312\353\363\341 <bar@foo.invalid>".force_encoding('ASCII-8BIT'),
+      [ { :name => "\322\315\322 \312\353\363\341".force_encoding('ASCII-8BIT'),
+	  :display_name => "\322\315\322 \312\353\363\341".force_encoding('ASCII-8BIT'),
 	  :address => 'bar@foo.invalid',
 	  :comments => nil,
 	  :domain => 'foo.invalid',
 	  :local => 'bar',
-	  :format => "\"\322\315\322 \312\353\363\341\" <bar@foo.invalid>",
+	  :format => "\"\322\315\322 \312\353\363\341\" <bar@foo.invalid>".force_encoding('ASCII-8BIT'),
 	} ] ]
   end
 

--- a/test/testbase.rb
+++ b/test/testbase.rb
@@ -39,7 +39,7 @@ rescue LoadError
 end
 
 class TestBase < Test::Unit::TestCase
-  include Config
+  include RbConfig
 
   attr_reader :scratch_dir
 

--- a/test/testmessage.rb
+++ b/test/testmessage.rb
@@ -141,7 +141,7 @@ Second body line
   def test_decode
     message = RMail::Message.new
 
-    all_bytes = ''
+    all_bytes = ''.force_encoding('ASCII-8BIT')
     0.upto(255) do |i|
       all_bytes << i
     end


### PR DESCRIPTION
Ruby 2.0 changes for the test suite:
- Use `RbConfig` - `Config` is depracated
- Fix encoding where `ASCII-8BIT` is expected

These changes require that the lib itself is patched by my proposed patch [1].

[1] https://github.com/matta/rubymail/pull/2
